### PR TITLE
Separating RenderSystem into multiple systems.

### DIFF
--- a/include/ClearSystem.h
+++ b/include/ClearSystem.h
@@ -1,0 +1,13 @@
+#ifndef CLEAR_SYSTEM_H
+#define CLEAR_SYSTEM_H
+
+#include "System.h"
+
+class ClearSystem : public System<ClearSystem>
+{
+public:
+    virtual ~ClearSystem(void);
+    virtual void Update(EntityManager* pManager, float dt, float tt);
+};
+
+#endif

--- a/include/SkyboxSystem.h
+++ b/include/SkyboxSystem.h
@@ -1,0 +1,13 @@
+#ifndef SKYBOX_SYSTEM_H
+#define SKYBOX_SYSTEM_H
+
+#include "System.h"
+
+class SkyboxSystem : public System<SkyboxSystem>
+{
+public:
+    virtual ~SkyboxSystem(void);
+    virtual void Update(EntityManager* pManager, float dt, float tt);
+};
+
+#endif

--- a/include/SwapSystem.h
+++ b/include/SwapSystem.h
@@ -1,0 +1,13 @@
+#ifndef SWAP_SYSTEM_H
+#define SWAP_SYSTEM_H
+
+#include "System.h"
+
+class SwapSystem : public System<SwapSystem>
+{
+public:
+    virtual ~SwapSystem(void);
+    virtual void Update(EntityManager* pManager, float dt, float tt);
+};
+
+#endif

--- a/src/ClearSystem.cpp
+++ b/src/ClearSystem.cpp
@@ -1,0 +1,29 @@
+#include "ClearSystem.h"
+
+// Managers
+#include "EntityManager.h"
+#include "ResourceManager.h"
+
+// DirectX
+#include <d3d11.h>
+
+using namespace DirectX;
+
+ClearSystem::~ClearSystem(void)
+{
+    /* Nothing to do. */
+}
+
+void ClearSystem::Update(EntityManager* pManager, float dt, float tt)
+{
+    ResourceManager* pResource = ResourceManager::Instance();
+
+    ID3D11DeviceContext* pDeviceContext = pResource->GetDeviceContext();
+    ID3D11RenderTargetView* pRenderTarget = pResource->GetRenderTargetView();
+    ID3D11DepthStencilView* pDepthStencilView = pResource->GetDepthStencilView();
+
+    // Clear the screen to black.
+    const float color[] = {0.0f, 0.0f, 0.0f, 0.0f };
+    pDeviceContext->ClearRenderTargetView(pRenderTarget, color);
+    pDeviceContext->ClearDepthStencilView(pDepthStencilView, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+}

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -22,8 +22,11 @@
 
 // Systems
 #include "PhysicsSystem.h"
-#include "RenderSystem.h"
 #include "InputControllerSystem.h"
+#include "ClearSystem.h"
+#include "RenderSystem.h"
+#include "SkyboxSystem.h"
+#include "SwapSystem.h"
 
 // For the DirectX Math library
 using namespace DirectX;
@@ -129,8 +132,11 @@ void GameState::Enter( void )
         // Register Systems for demonstration.
         EntityManager* pEntity = EntityManager::Instance();
         pEntity->AddSystem<PhysicsSystem>();
-        pEntity->AddSystemWithPriority<RenderSystem, 0>();
-		pEntity->AddSystemWithPriority<InputControllerSystem, 1>();
+		pEntity->AddSystem<InputControllerSystem>();
+        pEntity->AddSystem<ClearSystem>();
+        pEntity->AddSystem<RenderSystem>();
+        pEntity->AddSystem<SkyboxSystem>();
+        pEntity->AddSystem<SwapSystem>();
 
         // Generate 50 GameEntities for demonstration.
         srand(time(0));

--- a/src/RenderSystem.cpp
+++ b/src/RenderSystem.cpp
@@ -28,18 +28,6 @@ void RenderSystem::Update(EntityManager* pManager, float dt, float tt )
     ResourceManager* pResource = ResourceManager::Instance();
     ID3D11Device* pDevice = pResource->GetDevice();
     ID3D11DeviceContext* pDeviceContext = pResource->GetDeviceContext();
-    ID3D11RenderTargetView* pRender = pResource->GetRenderTargetView();
-    ID3D11DepthStencilView* pDepthStencil = pResource->GetDepthStencilView();
-    IDXGISwapChain* pSwapChain = pResource->GetSwapChain();
-
-    // Background color (Cornflower Blue in this case) for clearing
-    const float color[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-
-    // Clear the render target and depth buffer (erases what's on the screen)
-    pDeviceContext->ClearRenderTargetView(pRender, color);
-    pDeviceContext->ClearDepthStencilView(pDepthStencil, D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
-    pDeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-
     Camera* pCamera = CameraManager::Instance()->GetActiveCamera();
     XMFLOAT3 camPos = pCamera->transform.GetTranslation();
 
@@ -150,51 +138,7 @@ void RenderSystem::Update(EntityManager* pManager, float dt, float tt )
         pPixelShader->SetShader(false);
 
         // Draw the GameEntity
+        pDeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
         pDeviceContext->DrawIndexed(pMesh->GetIndexCount(), 0, 0);
     }
-
-    // Render the Skybox.
-    {
-        ISimpleShader   *pSkyVertex = pResource->GetShader("SkyboxVertex"),
-                        *pSkyPixel = pResource->GetShader("SkyboxPixel");
-        ID3D11RasterizerState* pRasterizer = pResource->GetRasterizerState("Skybox_Rasterizer");
-        ID3D11DepthStencilState* pDepthStencil = pResource->GetDepthStencilState("Skybox_DepthStencil");
-        ID3D11ShaderResourceView* pSkySRV = pResource->GetTexture("CubeMap");
-
-        // Update Mesh data.
-        Mesh* pCube = pResource->GetMesh("Cube"); 
-        ID3D11Buffer* vb = pCube->GetVertexBuffer();
-        ID3D11Buffer* ib = pCube->GetIndexBuffer();
-        UINT stride = sizeof(Vertex);
-        UINT offset = 0;
-        pDeviceContext->IASetVertexBuffers(0, 1, &vb, &stride, &offset);
-        pDeviceContext->IASetIndexBuffer(ib, DXGI_FORMAT_R32_UINT, 0);
-
-        // Send the matrices.
-        pSkyVertex->SetMatrix4x4("view", pCamera->GetViewMatrix());
-        pSkyVertex->SetMatrix4x4("projection", pCamera->GetProjectionMatrix());
-        pSkyVertex->CopyBufferData("PerFrame");
-
-        // Send the texure and sampler.
-        pSkyPixel->SetShaderResourceView("skybox", pSkySRV);
-        pSkyPixel->SetSamplerState("trilinear", pResource->GetSamplerState("trilinear"));
-
-        // Set Shader without copying buffers.
-        pSkyVertex->SetShader(false);
-        pSkyPixel->SetShader(false);
-
-        // Set Rasterizer and DepthStencil.
-        pDeviceContext->RSSetState(pRasterizer);
-        pDeviceContext->OMSetDepthStencilState(pDepthStencil, 0);
-
-        // Render the Skybox.
-        pDeviceContext->DrawIndexed(pCube->GetIndexCount(), 0, 0);
-
-        // Reset Rasterizer and DepthStencil.
-        pDeviceContext->RSSetState(nullptr);
-        pDeviceContext->OMSetDepthStencilState(nullptr, 0);
-    }
-
-    // Present the buffer
-    HR(pSwapChain->Present(0, 0));
 }

--- a/src/SkyboxSystem.cpp
+++ b/src/SkyboxSystem.cpp
@@ -1,0 +1,65 @@
+#include "SkyboxSystem.h"
+
+// Managers
+#include "EntityManager.h"
+#include "ResourceManager.h"
+#include "CameraManager.h"
+
+// DirectX
+#include <d3d11.h>
+#include "DXMacros.h"
+#include "SimpleShader.h"
+#include "Vertex.h"
+#include "Mesh.h"
+
+using namespace DirectX;
+
+SkyboxSystem::~SkyboxSystem(void)
+{
+    /* Nothing to do. */
+}
+
+void SkyboxSystem::Update(EntityManager* pManager, float dt, float tt)
+{
+    ResourceManager* pResource = ResourceManager::Instance();
+    ID3D11DeviceContext* pDeviceContext = pResource->GetDeviceContext();
+    ID3D11RasterizerState* pRasterizer = pResource->GetRasterizerState("Skybox_Rasterizer");
+    ID3D11DepthStencilState* pDepthStencil = pResource->GetDepthStencilState("Skybox_DepthStencil");
+    ID3D11ShaderResourceView* pSkySRV = pResource->GetTexture("CubeMap");
+    ISimpleShader   *pSkyVertex = pResource->GetShader("SkyboxVertex"),
+                    *pSkyPixel = pResource->GetShader("SkyboxPixel");
+    Camera* pCamera = CameraManager::Instance()->GetActiveCamera();
+
+    // Update Mesh data.
+    Mesh* pCube = pResource->GetMesh("Cube");
+    ID3D11Buffer* vb = pCube->GetVertexBuffer();
+    ID3D11Buffer* ib = pCube->GetIndexBuffer();
+    UINT stride = sizeof(Vertex);
+    UINT offset = 0;
+    pDeviceContext->IASetVertexBuffers(0, 1, &vb, &stride, &offset);
+    pDeviceContext->IASetIndexBuffer(ib, DXGI_FORMAT_R32_UINT, 0);
+
+    // Send the matrices.
+    pSkyVertex->SetMatrix4x4("view", pCamera->GetViewMatrix());
+    pSkyVertex->SetMatrix4x4("projection", pCamera->GetProjectionMatrix());
+    pSkyVertex->CopyBufferData("PerFrame");
+
+    // Send the texure and sampler.
+    pSkyPixel->SetShaderResourceView("skybox", pSkySRV);
+    pSkyPixel->SetSamplerState("trilinear", pResource->GetSamplerState("trilinear"));
+
+    // Set Shader without copying buffers.
+    pSkyVertex->SetShader(false);
+    pSkyPixel->SetShader(false);
+
+    // Set Rasterizer and DepthStencil.
+    pDeviceContext->RSSetState(pRasterizer);
+    pDeviceContext->OMSetDepthStencilState(pDepthStencil, 0);
+
+    // Render the Skybox.
+    pDeviceContext->DrawIndexed(pCube->GetIndexCount(), 0, 0);
+
+    // Reset Rasterizer and DepthStencil.
+    pDeviceContext->RSSetState(nullptr);
+    pDeviceContext->OMSetDepthStencilState(nullptr, 0);
+}

--- a/src/SwapSystem.cpp
+++ b/src/SwapSystem.cpp
@@ -1,0 +1,25 @@
+#include "SwapSystem.h"
+
+// Managers
+#include "EntityManager.h"
+#include "ResourceManager.h"
+
+// DirectX
+#include <d3d11.h>
+#include "DXMacros.h"
+
+using namespace DirectX;
+
+SwapSystem::~SwapSystem(void)
+{
+    /* Nothing to do. */
+}
+
+void SwapSystem::Update(EntityManager* pManager, float dt, float tt)
+{
+    ResourceManager* pResource = ResourceManager::Instance();
+    IDXGISwapChain* pSwapChain = pResource->GetSwapChain();
+
+    // Present the buffer
+    HR(pSwapChain->Present(0,0));
+}

--- a/vs2015/DirectX11_Starter.vcxproj
+++ b/vs2015/DirectX11_Starter.vcxproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <ClInclude Include="..\include\Camera.h" />
     <ClInclude Include="..\include\CameraManager.h" />
+    <ClInclude Include="..\include\ClearSystem.h" />
     <ClInclude Include="..\include\CollisionComponent.h" />
     <ClInclude Include="..\include\CollisionSphere.h" />
     <ClInclude Include="..\include\Component.h" />
@@ -114,7 +115,9 @@
     <ClInclude Include="..\include\ResourceManager.h" />
     <ClInclude Include="..\include\SimpleShader.h" />
     <ClInclude Include="..\include\Singleton.h" />
+    <ClInclude Include="..\include\SkyboxSystem.h" />
     <ClInclude Include="..\include\StateMachine.h" />
+    <ClInclude Include="..\include\SwapSystem.h" />
     <ClInclude Include="..\include\System.h" />
     <ClInclude Include="..\include\Transform.h" />
     <ClInclude Include="..\include\TransformComponent.h" />
@@ -124,6 +127,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\Camera.cpp" />
     <ClCompile Include="..\src\CameraManager.cpp" />
+    <ClCompile Include="..\src\ClearSystem.cpp" />
     <ClCompile Include="..\src\CollisionSphere.cpp" />
     <ClCompile Include="..\src\Component.cpp" />
     <ClCompile Include="..\src\DebugCamera.cpp" />
@@ -140,6 +144,8 @@
     <ClCompile Include="..\src\RenderSystem.cpp" />
     <ClCompile Include="..\src\ResourceManager.cpp" />
     <ClCompile Include="..\src\SimpleShader.cpp" />
+    <ClCompile Include="..\src\SkyboxSystem.cpp" />
+    <ClCompile Include="..\src\SwapSystem.cpp" />
     <ClCompile Include="..\src\System.cpp" />
     <ClCompile Include="..\src\Transform.cpp" />
     <ClCompile Include="..\src\InputControllerSystem.cpp" />

--- a/vs2015/DirectX11_Starter.vcxproj.filters
+++ b/vs2015/DirectX11_Starter.vcxproj.filters
@@ -162,6 +162,15 @@
     <ClInclude Include="..\include\CollisionComponent.h">
       <Filter>Header Files\Components</Filter>
     </ClInclude>
+    <ClInclude Include="..\include\ClearSystem.h">
+      <Filter>Header Files\Systems</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\SkyboxSystem.h">
+      <Filter>Header Files\Systems</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\SwapSystem.h">
+      <Filter>Header Files\Systems</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\ExitState.cpp">
@@ -226,6 +235,15 @@
     </ClCompile>
     <ClCompile Include="..\src\CollisionSphere.cpp">
       <Filter>Source Files\Game</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ClearSystem.cpp">
+      <Filter>Source Files\Systems</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\SkyboxSystem.cpp">
+      <Filter>Source Files\Systems</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\SwapSystem.cpp">
+      <Filter>Source Files\Systems</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Separated RenderSystem into ClearSystem, RenderSystem, SkyboxSystem, and
SwapSystem. This was done to simplify the RenderSystem::Update function, and to
allow addition/removal of additional rendering systems. For example, the
addition of a UIRenderSystem between SkyboxSystem and SwapSystem. ClearSystem is
responsible for clearing the screen, RenderSystem now only handles rendering all
models, SkyboxSystem is now responsible for rendering the space skybox, and
SwapSystem is responsible for presenting the IDXGISwapChain.
